### PR TITLE
Refactor loop logic in construct_templates()

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() -> std::io::Result<()> {
         vital_files
             .par_iter()
             .progress()
-            .map(|vf| compute_sampen_for_vital_file(M, &vf))
+            .map(|vf| compute_sampen_for_vital_file(M, vf))
             .collect::<Vec<VitalEntropies>>()
     };
     let duration = start.elapsed();
@@ -29,7 +29,7 @@ fn main() -> std::io::Result<()> {
     let entropy_csv: String = {
         sample_entropies
             .iter()
-            .map(|ve| vital_entropy_to_csv_line(&ve))
+            .map(|ve| vital_entropy_to_csv_line(ve))
             .collect::<Vec<String>>()
             .join("")
     };
@@ -139,11 +139,11 @@ fn read_csv(path: &str) -> Result<VitalFile, Box<dyn Error>> {
 
 fn read_glob_into_vitalfiles(glob_pattern: &String) -> Vec<VitalFile> {
     let bar = {
-        let glob_files = glob(&glob_pattern).expect("Failed to read glob pattern.");
+        let glob_files = glob(glob_pattern).expect("Failed to read glob pattern.");
         ProgressBar::new(glob_files.count() as u64)
     };
 
-    let glob_files = glob(&glob_pattern).expect("Failed to read glob pattern.");
+    let glob_files = glob(glob_pattern).expect("Failed to read glob pattern.");
     let mut vital_files: Vec<VitalFile> = Vec::new();
     for file in glob_files {
         let path: String = match file {

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,18 +60,18 @@ fn compute_sampen_for_vital_file(m: usize, vitalf: &VitalFile) -> VitalEntropies
     let mbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(vitalf.mbp.clone()));
     let dbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(vitalf.dbp.clone()));
 
-    return VitalEntropies {
+    VitalEntropies {
         name: vitalf.name.clone(),
         sbp_sampen,
         mbp_sampen,
         dbp_sampen,
-    };
+    }
 }
 
 fn compute_sampen_for_wave(m: usize, data: Vec<f32>) -> f32 {
     let stdev: f32 = stats::standard_deviation(&data);
     let r: f32 = stdev * 0.2;
-    return stats::sample_entropy(m, r, &data);
+    stats::sample_entropy(m, r, &data)
 }
 
 fn vital_entropy_to_csv_line(ve: &VitalEntropies) -> String {
@@ -84,7 +84,7 @@ fn vital_entropy_to_csv_line(ve: &VitalEntropies) -> String {
     line = line + &ve.mbp_sampen.to_string() + &comma;
     line = line + &ve.dbp_sampen.to_string() + &newline;
 
-    return line;
+    line
 }
 
 /// Reads waveform data from a file into a vector.
@@ -158,5 +158,5 @@ fn read_glob_into_vitalfiles(glob_pattern: &String) -> Vec<VitalFile> {
         bar.inc(1);
     }
 
-    return vital_files;
+    vital_files
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,9 @@ fn compute_sampen_for_vital_file(m: usize, vitalf: &VitalFile) -> VitalEntropies
 
     return VitalEntropies {
         name: vitalf.name.clone(),
-        sbp_sampen: sbp_sampen,
-        mbp_sampen: mbp_sampen,
-        dbp_sampen: dbp_sampen,
+        sbp_sampen,
+        mbp_sampen,
+        dbp_sampen,
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> std::io::Result<()> {
     let entropy_csv: String = {
         sample_entropies
             .iter()
-            .map(|ve| vital_entropy_to_csv_line(ve))
+            .map(vital_entropy_to_csv_line)
             .collect::<Vec<String>>()
             .join("")
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use csv;
 use glob::glob;
 use indicatif::{ParallelProgressIterator, ProgressBar};
 use rayon::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn read_csv(path: &str) -> Result<VitalFile, Box<dyn Error>> {
 /// * `glob_pattern` - a String pattern for glob to use.
 ///
 
-fn read_glob_into_vitalfiles(glob_pattern: &String) -> Vec<VitalFile> {
+fn read_glob_into_vitalfiles(glob_pattern: &str) -> Vec<VitalFile> {
     let bar = {
         let glob_files = glob(glob_pattern).expect("Failed to read glob pattern.");
         ProgressBar::new(glob_files.count() as u64)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2,20 +2,14 @@
 ///
 /// # Arguments
 ///
-/// * `m` - the window size for a single template.
-/// * `data` - the time series data.
+/// * `window_size` - the window size for a single template.
+/// * `ts_data` - the time series data.
 ///
-fn construct_templates(m: usize, data: &Vec<f32>) -> Vec<Vec<f32>> {
-    let mut templates: Vec<Vec<f32>> = Vec::new();
-    let mut new_template: Vec<f32>;
-    for i in m..data.len() + 1 {
-        new_template = Vec::new();
-        for j in (i - m)..i {
-            new_template.push(data[j]);
-        }
-        templates.push(new_template);
-    }
-    return templates;
+fn construct_templates(window_size: usize, ts_data: &Vec<f32>) -> Vec<Vec<f32>> {
+    let num_windows = ts_data.len() - window_size + 1;
+    return (0..num_windows)
+        .map(|x| ts_data[x..x + window_size].to_vec())
+        .collect::<Vec<Vec<f32>>>();
 }
 
 /// Gets the number of matches for a vector of templates.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -24,7 +24,7 @@ fn get_matches(templates: &Vec<Vec<f32>>, r: &f32) -> u32 {
 
     for i in 0..templates.len() {
         for j in i + 1..templates.len() {
-            if is_match(&templates[i], &templates[j], &r) {
+            if is_match(&templates[i], &templates[j], r) {
                 matches += 1;
             }
         }
@@ -62,9 +62,9 @@ fn is_match(vec_1: &Vec<f32>, vec_2: &Vec<f32>, r: &f32) -> bool {
 /// * `data` - a vector containing the waveform data.
 ///
 pub fn sample_entropy(m: usize, r: f32, data: &Vec<f32>) -> f32 {
-    let templates_size_m: Vec<Vec<f32>> = construct_templates(m, &data);
+    let templates_size_m: Vec<Vec<f32>> = construct_templates(m, data);
     let m_plus_one = m + 1;
-    let templates_size_m_plus_1: Vec<Vec<f32>> = construct_templates(m_plus_one, &data);
+    let templates_size_m_plus_1: Vec<Vec<f32>> = construct_templates(m_plus_one, data);
     let length_m_template_matches: f32 = get_matches(&templates_size_m, &r) as f32;
     let length_m_plus_1_template_matches: f32 = get_matches(&templates_size_m_plus_1, &r) as f32;
     let ratio: f32 = length_m_plus_1_template_matches / length_m_template_matches;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -118,7 +118,7 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
         numerator / denominator
     };
     // alpha hat is the estimate of the intercept parameter.
-    let alpha_hat: f32 = &ybar - &beta_hat * &xbar;
+    let alpha_hat: f32 = &ybar - beta_hat * xbar;
 
     let detrended_data = {
         let data_enum = &data.iter().enumerate().collect::<Vec<_>>();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -74,7 +74,7 @@ pub fn sample_entropy(m: usize, r: f32, data: &Vec<f32>) -> f32 {
 
 /// Vectorized one liner for computing the mean of a vector.
 pub fn mean(data: &Vec<f32>) -> f32 {
-    data.iter().sum::<f32>() as f32 / data.len() as f32
+    data.iter().sum::<f32>() / data.len() as f32
 }
 
 /// Vectorized read-only code that computes standard deviation.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,9 +7,9 @@
 ///
 fn construct_templates(window_size: usize, ts_data: &Vec<f32>) -> Vec<Vec<f32>> {
     let num_windows = ts_data.len() - window_size + 1;
-    return (0..num_windows)
+    (0..num_windows)
         .map(|x| ts_data[x..x + window_size].to_vec())
-        .collect::<Vec<Vec<f32>>>();
+        .collect::<Vec<Vec<f32>>>()
 }
 
 /// Gets the number of matches for a vector of templates.
@@ -29,7 +29,7 @@ fn get_matches(templates: &Vec<Vec<f32>>, r: &f32) -> u32 {
             }
         }
     }
-    return matches * 2;
+    matches * 2
 }
 
 /// Determines if two templates match.
@@ -69,7 +69,7 @@ pub fn sample_entropy(m: usize, r: f32, data: &Vec<f32>) -> f32 {
     let length_m_plus_1_template_matches: f32 = get_matches(&templates_size_m_plus_1, &r) as f32;
     let ratio: f32 = length_m_plus_1_template_matches / length_m_template_matches;
     let sampen: f32 = -(ratio).ln();
-    return sampen;
+    sampen
 }
 
 /// Vectorized one liner for computing the mean of a vector.
@@ -127,7 +127,7 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
             .map(|(ix, val)| *val - &alpha_hat - (&beta_hat * ((*ix as f32) + 1.0)))
             .collect::<Vec<f32>>()
     };
-    return detrended_data;
+    detrended_data
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -129,3 +129,20 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
     };
     return detrended_data;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constuct_templates_1() {
+        let expected: Vec<Vec<f32>> = vec![vec![1_f32], vec![2f32], vec![3_f32]];
+        assert_eq!(expected, construct_templates(1, &vec![1_f32, 2_f32, 3_f32]));
+    }
+
+    #[test]
+    fn test_constuct_templates_2() {
+        let expected: Vec<Vec<f32>> = vec![vec![1_f32, 2_f32], vec![2f32, 3_f32], vec![3_f32, 4f32], vec![4_f32, 5_f32]];
+        assert_eq!(expected, construct_templates(2, &vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32]));
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -118,13 +118,13 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
         numerator / denominator
     };
     // alpha hat is the estimate of the intercept parameter.
-    let alpha_hat: f32 = &ybar - beta_hat * xbar;
+    let alpha_hat: f32 = ybar - beta_hat * xbar;
 
     let detrended_data = {
         let data_enum = &data.iter().enumerate().collect::<Vec<_>>();
         data_enum
             .iter()
-            .map(|(ix, val)| *val - &alpha_hat - (&beta_hat * ((*ix as f32) + 1.0)))
+            .map(|(ix, val)| *val - alpha_hat - (beta_hat * ((*ix as f32) + 1.0)))
             .collect::<Vec<f32>>()
     };
     detrended_data

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -46,7 +46,7 @@ fn get_matches(templates: &Vec<Vec<f32>>, r: &f32) -> u32 {
 /// * `vec_2` - another immutable reference to a template vector.
 /// * `r` - the distance threshold over which a match does not occur.
 ///
-fn is_match(vec_1: &Vec<f32>, vec_2: &Vec<f32>, r: &f32) -> bool {
+fn is_match(vec_1: &[f32], vec_2: &Vec<f32>, r: &f32) -> bool {
     let threshold = *r;
     return vec_1
         .iter()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -142,7 +142,15 @@ mod tests {
 
     #[test]
     fn test_constuct_templates_2() {
-        let expected: Vec<Vec<f32>> = vec![vec![1_f32, 2_f32], vec![2f32, 3_f32], vec![3_f32, 4f32], vec![4_f32, 5_f32]];
-        assert_eq!(expected, construct_templates(2, &vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32]));
+        let expected: Vec<Vec<f32>> = vec![
+            vec![1_f32, 2_f32],
+            vec![2f32, 3_f32],
+            vec![3_f32, 4f32],
+            vec![4_f32, 5_f32],
+        ];
+        assert_eq!(
+            expected,
+            construct_templates(2, &vec![1_f32, 2_f32, 3_f32, 4_f32, 5_f32])
+        );
     }
 }


### PR DESCRIPTION
Assume (and please validate this) that a window is defined as starting from
index 0 of ts_data and only iterating until there are no more "full" windows (i.e.
a window may never have fewer than window_size elements).

The following would demonstrate each iteration of a loop needed to iterate
over each unique window of the data:

window_size = 2
ts_data.len() = 5

```
12345 <- ts_data
12    <- window_one   i=0
 23   <- window_two   i=1
  34  <- window_three i=2
   45 <- window_four  i=3
```

So this means we need the loop to iterate 4 times to capture each unique window
of the data, or 0 to 3. Rust's range syntax enforces the formula start ≤ x < end.
So we can write 0 to 3 in Rust's range syntax as 0..4 .

Lets try it with:
window_size = 1
ts_data.len() = 3

```
123 <- ts_data
1   <- window_one   i=0
 2  <- window_two   i=1
  3 <- window_three i=2
```

This time the loop needed to iterate three times, or 0 to 2. Again, with Rust's
range syntax this is represented as 0..3

In the original code this logic is expressed as the function window_size..ts_data.len() + 1

If we apply the original formula for calculating how many iterations we need we get:
  Example 1: 2..6
  Example 2: 1..4

The inner loop then applies logic to revert the starting index back to zero so by this
point it should be clear that we can clean up the looping logic to something a bit clearer
such as the following:

```rust
let num_windows = ts_data.len() - window_size + 1;
return (0..num_windows)
    .map(|x| ts_data[x..x + window_size].to_vec())
    .collect::<Vec<Vec<f32>>>();
```