### PR TITLE
simplify detrend logic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,9 @@ pub struct VitalEntropies {
 
 /// Computes sample entropy for a single VitalFile struct.
 fn compute_sampen_for_vital_file(m: usize, vitalf: &VitalFile) -> VitalEntropies {
-    let sbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(vitalf.sbp.clone()));
-    let mbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(vitalf.mbp.clone()));
-    let dbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(vitalf.dbp.clone()));
+    let sbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(&vitalf.sbp));
+    let mbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(&vitalf.mbp));
+    let dbp_sampen: f32 = compute_sampen_for_wave(m, stats::detrend_data(&vitalf.dbp));
 
     VitalEntropies {
         name: vitalf.name.clone(),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -73,12 +73,12 @@ pub fn sample_entropy(m: usize, r: f32, data: &Vec<f32>) -> f32 {
 }
 
 /// Vectorized one liner for computing the mean of a vector.
-pub fn mean(data: &Vec<f32>) -> f32 {
+pub fn mean(data: &[f32]) -> f32 {
     data.iter().sum::<f32>() / data.len() as f32
 }
 
 /// Vectorized read-only code that computes standard deviation.
-pub fn standard_deviation(data: &Vec<f32>) -> f32 {
+pub fn standard_deviation(data: &[f32]) -> f32 {
     let xbar: f32 = mean(data);
     let squared_err: Vec<f32> = data.iter().map(|x| (x - xbar).powf(2.0)).collect();
     return ((squared_err.iter().sum::<f32>()) / (data.len() as f32)).sqrt();

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -80,8 +80,8 @@ pub fn mean(data: &[f32]) -> f32 {
 /// Vectorized read-only code that computes standard deviation.
 pub fn standard_deviation(data: &[f32]) -> f32 {
     let xbar: f32 = mean(data);
-    let squared_err: Vec<f32> = data.iter().map(|x| (x - xbar).powf(2.0)).collect();
-    return ((squared_err.iter().sum::<f32>()) / (data.len() as f32)).sqrt();
+    let squared_err_sum: f32 = data.iter().fold(0_f32, |acc, x| acc + ((x - xbar).powf(2.0)));
+    (squared_err_sum / (data.len() as f32)).sqrt()
 }
 
 /// Detrends the data via a linear detrending.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -98,7 +98,7 @@ pub fn standard_deviation(data: &Vec<f32>) -> f32 {
 /// `data` - a mutable reference to the waveform data.
 ///
 pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
-    let xbar: f32 = ((data.len() as f32) + 1.0) / 2.0;
+    let xbar: f32 = (data.len() + 1) as f32 / 2.0;
     let ybar: f32 = mean(&data);
     // beta hat is the estimate of the slope parameter.
     let beta_hat: f32 = {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -118,14 +118,10 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
     // alpha hat is the estimate of the intercept parameter.
     let alpha_hat: f32 = ybar - beta_hat * xbar;
 
-    let detrended_data = {
-        let data_enum = &data.iter().enumerate().collect::<Vec<_>>();
-        data_enum
-            .iter()
-            .map(|(ix, val)| *val - alpha_hat - (beta_hat * ((*ix as f32) + 1.0)))
-            .collect::<Vec<f32>>()
-    };
-    detrended_data
+    data.iter()
+        .enumerate()
+        .map(|(ix, val)| val - alpha_hat - (beta_hat * ((ix as f32) + 1.0)))
+        .collect::<Vec<f32>>()
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -80,7 +80,9 @@ pub fn mean(data: &[f32]) -> f32 {
 /// Vectorized read-only code that computes standard deviation.
 pub fn standard_deviation(data: &[f32]) -> f32 {
     let xbar: f32 = mean(data);
-    let squared_err_sum: f32 = data.iter().fold(0_f32, |acc, x| acc + ((x - xbar).powf(2.0)));
+    let squared_err_sum: f32 = data
+        .iter()
+        .fold(0_f32, |acc, x| acc + ((x - xbar).powf(2.0)));
     (squared_err_sum / (data.len() as f32)).sqrt()
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -104,19 +104,15 @@ pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
     let ybar: f32 = mean(&data);
     // beta hat is the estimate of the slope parameter.
     let beta_hat: f32 = {
-        let data_enum = &data.iter().enumerate().collect::<Vec<_>>();
-        let numerator: f32 = data_enum
-            .iter()
-            .map(|(x, y)| ((*x as f32) + 1.0 - xbar) * (*y - ybar))
-            .collect::<Vec<_>>()
-            .into_iter()
-            .sum::<f32>();
-        let denominator: f32 = data_enum
-            .iter()
-            .map(|(x, _y)| ((*x as f32) + 1.0 - xbar).powf(2.0))
-            .collect::<Vec<_>>()
-            .into_iter()
-            .sum::<f32>();
+        let (numerator, denominator): (f32, f32) =
+            data.iter()
+                .enumerate()
+                .fold((0_f32, 0_f32), |acc, (index, value)| {
+                    let temp = (index + 1) as f32 - xbar;
+                    let num_acc = acc.0 + (temp * (value - ybar));
+                    let den_acc = acc.1 + (temp.powf(2.0));
+                    (num_acc, den_acc)
+                });
         numerator / denominator
     };
     // alpha hat is the estimate of the intercept parameter.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -97,11 +97,11 @@ pub fn standard_deviation(data: &[f32]) -> f32 {
 /// be useful to speed the program up, but honestly it is already fairly fast.
 ///
 /// # Arguments
-/// `data` - a mutable reference to the waveform data.
+/// `data` - an immutable vector slice of waveform data.
 ///
-pub fn detrend_data(data: Vec<f32>) -> Vec<f32> {
+pub fn detrend_data(data: &[f32]) -> Vec<f32> {
     let xbar: f32 = (data.len() + 1) as f32 / 2.0;
-    let ybar: f32 = mean(&data);
+    let ybar: f32 = mean(data);
     // beta hat is the estimate of the slope parameter.
     let beta_hat: f32 = {
         let (numerator, denominator): (f32, f32) =


### PR DESCRIPTION
- Simplify xbar f32 typecasting
- Switch to passing in slices of vectors instead of references
- Remove needless vector creation
- Apply cargo fmt
- Optimize calculation of beta_hat
- Remove creation of temporary vector in return of detrended data
- Pass vector as slice instead of by value
