### PR TITLE
Revert match counting

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -33,7 +33,7 @@ fn get_matches(templates: &[Vec<f32>], threshold: &f32) -> usize {
             }
         }
     }
-    (matches * 2).try_into().unwrap()
+    matches.try_into().unwrap()
 }
 
 /// Determines if two templates match.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -24,12 +24,16 @@ fn construct_templates(window_size: usize, ts_data: &Vec<f32>) -> Vec<Vec<f32>> 
 /// * `threshold` - the distance threshold over which a match does not occur.
 ///
 fn get_matches(templates: &[Vec<f32>], threshold: &f32) -> usize {
-    templates
-        .iter()
-        .combinations(2)
-        .filter(|x| is_match(x[0], x[1], threshold))
-        .count()
-        * 2
+    let mut matches: u32 = 0;
+
+    for i in 0..templates.len() {
+        for j in i + 1..templates.len() {
+            if is_match(&templates[i], &templates[j], &threshold) {
+                matches += 1;
+            }
+        }
+    }
+    (matches * 2).try_into().unwrap()
 }
 
 /// Determines if two templates match.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 /// Constructs the template vectors for a given time series.
 ///
 /// # Arguments
@@ -32,7 +30,7 @@ fn get_matches(templates: &[Vec<f32>], threshold: &f32) -> usize {
 
     for i in 0..templates.len() {
         for j in i + 1..templates.len() {
-            if is_match(&templates[i], &templates[j], &threshold) {
+            if is_match(&templates[i], &templates[j], threshold) {
                 matches += 1;
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -14,9 +14,13 @@ fn construct_templates(window_size: usize, ts_data: &Vec<f32>) -> Vec<Vec<f32>> 
         .collect::<Vec<Vec<f32>>>()
 }
 
-/// Returns 2 times the number of unique pairs of template vectors where the
+/// Returns the number of unique pairs of template vectors where the
 /// chebyshev distance between each pair of vectors is less than the given
 /// threshold.
+///
+/// This function technically returns exactly half the matches, but since
+/// sample entropy is -ln(A/B), it doesn't matter if we divide both A and B
+/// by two.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
I have absolutely no clue why, but doing the match counting as an iterator causes a >100x slowdown of the code.
This branch reverts the iterator changes but keeps the changes to the variable names.